### PR TITLE
feat: analytics ask UI and RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - 집계 헬스 API (`apps/web-admin/src/app/api/health/route.ts`): 각 프로바이더 `/health` 호출 집계, `Authorization: Bearer DEV_TOKEN` 포함
 - GitHub Issues 초안 3건(#2 CSV↔스캔앱 매칭 안정화, #3 멀티테넌트 로그인/권한 기초, #4 헬스체크 API 구현)
 
+## [0.1.2] - 2025-08-21
+### Added
+- Items 업로드/목록/리셋 UI 추가 (`/admin/items`, `/admin/items/upload`)
+- 업로드 API 고도화(`/api/upload`): 서비스키 사용, `core.items` UPSERT(RLS/정책 포함)
+- Analytics 목업/요약: `core.sales` 테이블 + RPC(`generate_mock_sales`, `sales_summary_monthly`, `sales_recent`, `sales_top_sku_days`)
+- Analytics 페이지(`/admin/analytics/sales`): 목업 생성(자동 새로고침), 월별 표/막대차트, Top 5, 최근 50건
+- 자연어 질의 데모(`/admin/ask`, `/api/ask`): "최근 N일 top K sku", "월별 매출 추세"
+
+### Changed
+- 웹 API 런타임을 node로 고정하여 .env 로딩 안정화
+- 헤더/네비에 Items/Analytics/Ask 링크 추가
+
+### Fixed
+- Supabase 함수 시그니처 캐시 이슈 해결: `sales_recent`, `sales_top_sku_days` 재정의 및 pg_notify 리로드 가이드 반영
+
 ### Changed
 - Next.js App Router 기본 구성 정리, `experimental.appDir` 경고 제거
 - README 보강: 실행법(npm/pnpm 병기), 헬스 체크(집계/개별), 문서 운영 규칙

--- a/apps/web-admin/src/app/admin/analytics/sales/page.tsx
+++ b/apps/web-admin/src/app/admin/analytics/sales/page.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+export default function SalesAnalyticsPage() {
+  const defaultTenant = useMemo(() => process.env.NEXT_PUBLIC_TENANT_ID || '', []);
+  const [tenantId, setTenantId] = useState(defaultTenant);
+  const [days, setDays] = useState(7);
+  const [rows, setRows] = useState<any[]>([]);
+  const [recent, setRecent] = useState<any[]>([]);
+  const [lastRefreshed, setLastRefreshed] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [skuFilter, setSkuFilter] = useState('');
+  const [monthsLimit, setMonthsLimit] = useState(6);
+
+  const load = async () => {
+    const params = new URLSearchParams();
+    if (tenantId) params.set('tenant_id', tenantId);
+    params.set('recent', '1');
+    const res = await fetch(`/api/analytics/sales?${params.toString()}`, { cache: 'no-store' });
+    const json = await res.json();
+    setRows(json.rows || []);
+    setRecent(json.recent || []);
+    setLastRefreshed(new Date().toLocaleTimeString());
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onGenerate = async () => {
+    setLoading(true);
+    setMsg(null);
+    try {
+      const res = await fetch('/api/analytics/mock-sales', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tenant_id: tenantId, days }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setMsg(JSON.stringify(json, null, 2));
+        return;
+      }
+      setMsg(JSON.stringify(json, null, 2));
+      await load();
+    } catch (e: any) {
+      setMsg(e?.message || 'failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">Sales Analytics (Mock)</h1>
+
+      <div className="flex gap-2 items-end">
+        <div>
+          <label className="block text-sm mb-1">tenant_id</label>
+          <input className="border rounded px-3 py-2 w-[420px]" value={tenantId} onChange={e=>setTenantId(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">days</label>
+          <input type="number" className="border rounded px-3 py-2 w-28" value={days} onChange={e=>setDays(Number(e.target.value)||0)} />
+        </div>
+        <button onClick={async()=>{await onGenerate(); await load();}} disabled={loading} className="px-3 py-2 bg-blue-600 text-white rounded disabled:opacity-50">{loading?'생성 중...':'목업 생성(자동 새로고침)'}</button>
+        <button onClick={load} className="px-3 py-2 border rounded">요약 새로고침</button>
+        {lastRefreshed && <span className="text-sm text-gray-500">마지막 갱신 {lastRefreshed} · {rows.length} rows</span>}
+      </div>
+
+      <div className="flex gap-4 items-end">
+        <div>
+          <label className="block text-sm mb-1">SKU 필터(부분일치)</label>
+          <input className="border rounded px-3 py-2 w-60" value={skuFilter} onChange={e=>setSkuFilter(e.target.value)} placeholder="예: SKU-1001" />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">표시 개월수</label>
+          <select className="border rounded px-3 py-2" value={monthsLimit} onChange={e=>setMonthsLimit(Number(e.target.value))}>
+            <option value={3}>3</option>
+            <option value={6}>6</option>
+            <option value={12}>12</option>
+          </select>
+        </div>
+      </div>
+
+      {msg && <div className="bg-gray-50 border rounded px-3 py-2">{msg}</div>}
+
+      {/* 월별 매출 차트 (집계 rows 기반) */}
+      {(() => {
+        // 필터 적용
+        const fr = rows.filter(r => !skuFilter || String(r.sku || '').includes(skuFilter));
+        // month 라벨 만들기, 매출 합계(모든 SKU 합)
+        const m2rev = new Map<string, number>();
+        for (const r of fr) {
+          const d = new Date(r.month);
+          const key = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2, '0')}`;
+          m2rev.set(key, (m2rev.get(key) || 0) + Number(r.revenue || 0));
+        }
+        const labels = Array.from(m2rev.keys()).sort();
+        const sliced = labels.slice(Math.max(0, labels.length - monthsLimit));
+        const data = sliced.map(k => m2rev.get(k) || 0);
+        const max = Math.max(1, ...data);
+        const W = 800, H = 200, pad = 24;
+        const bw = Math.max(10, Math.floor((W - pad*2) / Math.max(1, data.length)) - 6);
+        return (
+          <div className="border rounded p-4">
+            <div className="font-medium mb-2">월별 매출 차트(합계)</div>
+            <svg width={W} height={H} className="max-w-full">
+              {data.map((v, i) => {
+                const x = pad + i * (bw + 6);
+                const h = Math.max(1, Math.round((v / max) * (H - pad*2)));
+                const y = H - pad - h;
+                return (
+                  <g key={i}>
+                    <rect x={x} y={y} width={bw} height={h} fill="#3b82f6" />
+                    <text x={x + bw/2} y={H - 6} textAnchor="middle" fontSize="10">{sliced[i]}</text>
+                  </g>
+                );
+              })}
+            </svg>
+          </div>
+        );
+      })()}
+
+      {/* Top 5 SKUs (latest month) */}
+      {(() => {
+        if (!rows.length) return null;
+        const months = rows.map(r => r.month).sort();
+        const latest = months[months.length - 1];
+        const bySku = new Map<string, number>();
+        for (const r of rows) {
+          if (r.month === latest) {
+            bySku.set(r.sku, (bySku.get(r.sku) || 0) + Number(r.revenue || 0));
+          }
+        }
+        const top = Array.from(bySku.entries()).sort((a,b)=>b[1]-a[1]).slice(0,5);
+        return (
+          <div className="border rounded p-4">
+            <div className="font-medium mb-2">Top 5 SKUs (최근월, 매출)</div>
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="text-left px-3 py-2">sku</th>
+                  <th className="text-left px-3 py-2">revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {top.map(([sku, rev]) => (
+                  <tr key={sku} className="border-t">
+                    <td className="px-3 py-2">{sku}</td>
+                    <td className="px-3 py-2">{rev.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      })()}
+
+      <div className="overflow-auto border rounded">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left px-3 py-2">month</th>
+              <th className="text-left px-3 py-2">sku</th>
+              <th className="text-left px-3 py-2">total_qty</th>
+              <th className="text-left px-3 py-2">revenue</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i} className="border-t">
+                <td className="px-3 py-2">{r.month}</td>
+                <td className="px-3 py-2">{r.sku}</td>
+                <td className="px-3 py-2">{r.total_qty}</td>
+                <td className="px-3 py-2">{r.revenue}</td>
+              </tr>
+            ))}
+            {!rows.length && (
+              <tr>
+                <td colSpan={4} className="px-3 py-6 text-center text-gray-500">No data</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="overflow-auto border rounded">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="text-left px-3 py-2">sold_at</th>
+              <th className="text-left px-3 py-2">sku</th>
+              <th className="text-left px-3 py-2">qty</th>
+              <th className="text-left px-3 py-2">price</th>
+            </tr>
+          </thead>
+          <tbody>
+            {recent.map((r, i) => (
+              <tr key={i} className="border-t">
+                <td className="px-3 py-2">{r.sold_at}</td>
+                <td className="px-3 py-2">{r.sku}</td>
+                <td className="px-3 py-2">{r.qty}</td>
+                <td className="px-3 py-2">{r.price}</td>
+              </tr>
+            ))}
+            {!recent.length && (
+              <tr>
+                <td colSpan={4} className="px-3 py-6 text-center text-gray-500">No recent rows</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+

--- a/apps/web-admin/src/app/admin/ask/page.tsx
+++ b/apps/web-admin/src/app/admin/ask/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+export default function AskPage() {
+  const defaultTenant = useMemo(() => process.env.NEXT_PUBLIC_TENANT_ID || '', []);
+  const [tenantId, setTenantId] = useState(defaultTenant);
+  const [q, setQ] = useState('최근 30일 top 5 sku');
+  const [res, setRes] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+
+  const onAsk = async () => {
+    setLoading(true);
+    setRes(null);
+    try {
+      const r = await fetch('/api/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: q, tenant_id: tenantId }),
+      });
+      const j = await r.json();
+      setRes(j);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-semibold">자연어 질의(데모)</h1>
+      <div className="space-y-3">
+        <div>
+          <label className="block text-sm mb-1">tenant_id</label>
+          <input className="border rounded px-3 py-2 w-full" value={tenantId} onChange={e=>setTenantId(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">질문</label>
+          <input className="border rounded px-3 py-2 w-full" value={q} onChange={e=>setQ(e.target.value)} placeholder="예: 최근 30일 top 5 sku / 월별 매출 추세" />
+        </div>
+        <div className="flex gap-2">
+          <button onClick={onAsk} disabled={loading} className="px-3 py-2 bg-blue-600 text-white rounded disabled:opacity-50">{loading?'질의 중...':'질의'}</button>
+          <a href="/admin/analytics/sales" className="px-3 py-2 border rounded">Analytics로</a>
+        </div>
+      </div>
+
+      {res && (
+        <div className="border rounded p-4">
+          <div className="font-medium mb-2">응답</div>
+          <pre className="text-sm overflow-auto">{JSON.stringify(res, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+

--- a/apps/web-admin/src/app/api/analytics/mock-sales/route.ts
+++ b/apps/web-admin/src/app/api/analytics/mock-sales/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import path from 'path';
+import dotenv from 'dotenv';
+
+// Load root .env for monorepo
+dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const tenantId = String(body.tenant_id || process.env.NEXT_PUBLIC_TENANT_ID || '');
+    const days = Number(body.days ?? 7);
+    if (!tenantId) return NextResponse.json({ error: 'tenant_id required' }, { status: 400 });
+
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!url) return NextResponse.json({ error: 'supabaseUrl missing' }, { status: 500 });
+    if (!serviceKey) return NextResponse.json({ error: 'supabase service key missing' }, { status: 500 });
+
+    // Only use public RPC (function seeds products internally)
+    const supabasePublic = createClient(url, serviceKey, { db: { schema: 'public' } });
+    const { data, error } = await supabasePublic.rpc('generate_mock_sales', { _tenant_id: tenantId, _days: days });
+    if (error) {
+      return NextResponse.json({ error: error.message, hint: (error as any).hint, details: (error as any).details }, { status: 500 });
+    }
+    return NextResponse.json({ generated: data ?? 0 });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'failed' }, { status: 500 });
+  }
+}
+
+

--- a/apps/web-admin/src/app/api/analytics/sales/route.ts
+++ b/apps/web-admin/src/app/api/analytics/sales/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
+
+export const runtime = 'nodejs';
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const tenantId = searchParams.get('tenant_id') || process.env.NEXT_PUBLIC_TENANT_ID || '';
+    const includeRecent = searchParams.get('recent') === '1';
+    if (!tenantId) return NextResponse.json({ error: 'tenant_id required' }, { status: 400 });
+
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!url) return NextResponse.json({ error: 'supabaseUrl missing' }, { status: 500 });
+    if (!serviceKey) return NextResponse.json({ error: 'supabase service key missing' }, { status: 500 });
+
+    const supabase = createClient(url, serviceKey, { db: { schema: 'public' } });
+    const { data, error } = await supabase.rpc('sales_summary_monthly', { _tenant_id: tenantId });
+    if (error) throw error;
+    let recent: any[] = [];
+    if (includeRecent) {
+      const r = await supabase.rpc('sales_recent', { _tenant_id: tenantId, _limit: 50 });
+      if (r.error) throw r.error;
+      recent = r.data || [];
+    }
+    return NextResponse.json({ rows: data ?? [], recent });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'failed' }, { status: 500 });
+  }
+}
+
+

--- a/apps/web-admin/src/app/api/ask/route.ts
+++ b/apps/web-admin/src/app/api/ask/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
+export const runtime = 'nodejs';
+
+function parseDays(q: string): number | null {
+  const m = q.match(/(\d{1,3})\s*(day|days|일)/i);
+  if (m) return Math.max(1, Math.min(365, parseInt(m[1], 10)));
+  if (/week|주/i.test(q)) return 7;
+  if (/month|개월|달/i.test(q)) return 30;
+  return null;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const question = String(body.question || '')
+      .trim();
+    const tenantId = String(body.tenant_id || process.env.NEXT_PUBLIC_TENANT_ID || '');
+    if (!question) return NextResponse.json({ error: 'question required' }, { status: 400 });
+    if (!tenantId) return NextResponse.json({ error: 'tenant_id required' }, { status: 400 });
+
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!url || !serviceKey) return NextResponse.json({ error: 'supabase env missing' }, { status: 500 });
+    const supabase = createClient(url, serviceKey, { db: { schema: 'public' } });
+
+    // 아주 단순한 라우팅(데모): top / monthly
+    const lower = question.toLowerCase();
+    if (/(top|상위)/i.test(question)) {
+      const days = parseDays(question) ?? 30;
+      const limitMatch = question.match(/top\s*(\d+)/i);
+      const limit = limitMatch ? Math.min(20, parseInt(limitMatch[1], 10)) : 5;
+      const { data, error } = await supabase.rpc('sales_top_sku_days', { _tenant_id: tenantId, _days: days, _limit: limit });
+      if (error) throw error;
+      return NextResponse.json({ intent: 'top_sku_days', params: { days, limit }, rows: data ?? [] });
+    }
+
+    if (/(monthly|월별|trend|추세)/i.test(question)) {
+      const { data, error } = await supabase.rpc('sales_summary_monthly', { _tenant_id: tenantId });
+      if (error) throw error;
+      return NextResponse.json({ intent: 'monthly_summary', rows: data ?? [] });
+    }
+
+    return NextResponse.json({ error: 'unsupported question. try: "최근 30일 top 5 sku" or "월별 매출 추세"' }, { status: 400 });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'failed' }, { status: 500 });
+  }
+}
+
+

--- a/apps/web-admin/src/app/layout.tsx
+++ b/apps/web-admin/src/app/layout.tsx
@@ -21,6 +21,8 @@ export default function RootLayout({
                 <a href="/" className="text-xl font-semibold text-gray-900">Joogo WMS/OMS</a>
                 <a href="/admin/items" className="text-sm text-blue-600 hover:underline">Items</a>
                 <a href="/admin/items/upload" className="text-sm text-blue-600 hover:underline">CSV 업로드</a>
+                <a href="/admin/analytics/sales" className="text-sm text-blue-600 hover:underline">Analytics</a>
+                <a href="/admin/ask" className="text-sm text-blue-600 hover:underline">Ask</a>
               </div>
               <div className="flex items-center space-x-4">
                 <span className="text-sm text-gray-500">


### PR DESCRIPTION
Adds analytics mock/summaries (core.sales + RPC), analytics UI (table/bar chart/top5/recent), natural language demo (/admin/ask + /api/ask), items upload/list/reset polish, runtime/env hardening, and nav links. Bump CHANGELOG to 0.1.2.